### PR TITLE
fix NRP-1: use I64 for timestamp

### DIFF
--- a/nrp-1.md
+++ b/nrp-1.md
@@ -49,7 +49,7 @@ Event ::
 
 Id :: [Byte ^ 32]     -- indicates fixed-size byte string of exactly 32 bytes
 Pubkey :: [Byte ^ 32]
-Timestamp :: U32 -- indicates 32-bit unsigned integer
+Timestamp :: I64 -- indicates 64-bit signed integer
 Kind :: U64 -- indicates 64-bit unsigned integer
 OtsHash :: [Byte ^ 32]
 


### PR DESCRIPTION
U32 timestamp would overflow in year 2106

https://en.wikipedia.org/wiki/Year_2038_problem

> Most operating systems designed to run on 64-bit hardware already use signed 64-bit `time_t` integers.
