### PR TITLE
FIXME: allow multiple files in content

### DIFF
--- a/nrp-1.md
+++ b/nrp-1.md
@@ -61,6 +61,7 @@ TagName :: [AsciiPrintable ^ 1..0xFF] -- indicates string from 1 to 255 chars
 TagData :: [Entry ^ 0..0xFF]
 Entry :: [Byte ^ 1..0xFF]     -- inticates non-empty byte string up to 255 bytes
 
+-- FIXME: allow multiple files in content
 Content :: [Byte ^ 0..0xFFFFFF] -- inticates byte string up to 2^24 bytes
 Signature :: [Byte ^ 64] -- indicates Shnorr signature
 


### PR DESCRIPTION
currently, content can hold only one file, usually utf8-encoded text.

it would be nice to send multiple files per event, for example:

- text with images
- text with video
- video with subtitles
- arbitrary folders of files

benefits:

- avoid sending images as base64
- reuse one image in multiple places
- avoid muxing streams into one video file
- avoid workarounds like zip-archives

this would make nostr more similar to bittorrent/[zeronet](https://github.com/HelloZeroNet/ZeroNet)/[twister](https://github.com/miguelfreitas/twister-core)
